### PR TITLE
Fix typo in world.js

### DIFF
--- a/scripts/homepage/world.js
+++ b/scripts/homepage/world.js
@@ -9,7 +9,7 @@ $(function()
 	canvas.width = $('#canvas-container').width();
 	$(window).resize(function(){
 		var width =  $('#canvas-container').width();;
-		canvas.width = witdh;
+		canvas.width = width;
 		world.width = width;
 	})
 


### PR DESCRIPTION
Typo witdh to width should fix error where demos stopped working (Specifically self organizing map)