### PR TITLE
Optimization for Second-order Networks

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -142,6 +142,7 @@ Network.prototype = {
       hardcode += "F[" + optimized.variables[i].id + "] = " + (optimized.variables[
         i].value || 0) + "; ";
     hardcode += "var activate = function(input){\n";
+    hardcode += "influences = [];";
     for (var i in optimized.inputs)
       hardcode += "F[" + optimized.inputs[i] + "] = input[" + i + "]; ";
     for (var currentLayer in optimized.activation_sentences) {


### PR DESCRIPTION
I made some changes to forward propagation codes (including the code generator) and achieved approximately 50%-100% performance boost on training second-order neural networks (those with gatings). The optimized codes give exactly the same result as original ones.

Credit goes to Dr. Monner's original paper, where Eq.18 states,
<p align="center"><img src="http://latex.codecogs.com/gif.latex?\epsilon^k_{ji} = g_{kk} w_{kk} + f'_k (s_j) \epsilon_{ji} \underbrace{\left(\frac{\partial g_{kk}}{\partial y_j} w_{kk} \hat{s_k} + \sum_{a \neq k} w_{ka} y_a \right)}"/></p>

The underbraced part is independent of i so I moved them out of the loop over i. Those values are precalculated and stored in an array.

This little change reduces the generated codes by half for LSTM networks!