### PR TITLE
Parallelize neuron activation sequence in self-connected layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@
 
 # Node.
 node_modules
+
+# Tmp files.
+*~
+
+# Dot.
+*.dot
+*.png
+
+# Demo.
+demo.js
+

--- a/src/layer.js
+++ b/src/layer.js
@@ -223,11 +223,14 @@ Layer.connection = function LayerConnection(fromLayer, toLayer, type, weights) {
       this.type = Layer.connectionType.ALL_TO_ALL;
   }
 
-  if (this.type == Layer.connectionType.ALL_TO_ALL) {
+  if (this.type == Layer.connectionType.ALL_TO_ALL ||
+      this.type == Layer.connectionType.ALL_TO_ELSE) {
     for (var here in this.from.list) {
       for (var there in this.to.list) {
         var from = this.from.list[here];
         var to = this.to.list[there];
+        if(this.type == Layer.connectionType.ALL_TO_ELSE && from == to)
+          continue;
         var connection = from.project(to, weights);
 
         this.connections[connection.ID] = connection;
@@ -253,6 +256,7 @@ Layer.connection = function LayerConnection(fromLayer, toLayer, type, weights) {
 Layer.connectionType = {};
 Layer.connectionType.ALL_TO_ALL = "ALL TO ALL";
 Layer.connectionType.ONE_TO_ONE = "ONE TO ONE";
+Layer.connectionType.ALL_TO_ELSE = "ALL TO ELSE";
 
 // types of gates
 Layer.gateType = {};

--- a/src/layer.js
+++ b/src/layer.js
@@ -9,6 +9,7 @@ function Layer(size, label) {
   this.size = size | 0;
   this.list = [];
   this.label = label || null;
+  this.connectedto = [];
 
   while (size--) {
     var neuron = new Neuron();
@@ -115,6 +116,7 @@ Layer.prototype = {
         gater.gate(gated);
       }
     }
+    connection.gatedfrom.push({layer: this, type: type});
   },
 
   // true or false whether the whole layer is self-connected or not
@@ -211,6 +213,7 @@ Layer.connection = function LayerConnection(fromLayer, toLayer, type, weights) {
   this.connections = {};
   this.list = [];
   this.size = 0;
+  this.gatedfrom = [];
 
   if (typeof this.type == 'undefined')
   {
@@ -242,6 +245,8 @@ Layer.connection = function LayerConnection(fromLayer, toLayer, type, weights) {
       this.size = this.list.push(connection);
     }
   }
+  
+  fromLayer.connectedto.push(this);
 }
 
 // types of connections


### PR DESCRIPTION
This PR is **not** about parallelizing the library to run on multiple cores/gpu. It's about a bug in the sequence of activating neurons in self-connected layers.

We need to take great care when activating a self-connected layer (e.g. `memoryCell.project(memoryCell);`). Before this PR all neurons in such a layer are activated in sequence, which means **the former neurons always overwrite the activations fed to later neurons**, and the activations may mess up. The right way to do this is to **update the activations only after all neurons in the layer have been activated**.

This PR fixes the bug in forward propagation, including hardcoder (standalone hardcoder is fixed but not tested yet). I'm not sure yet if similar bug exists in back propagation. We have to fix these bugs if we want to parallelize (multi-corelize) it because we don't want resource conflicts.

The fixed codes pass the DSR task as well as the [timing task](https://github.com/cazala/synaptic/issues/30#issuecomment-97624779).

Notable changes:
* `Neuron` got two new properties: `.newactivation` and `.inselfconnectedlayer`
* `update_sentences` was added to the hardcoder which contains a few lines like this, `Neuron.activation = Neuron.newactivation;`