### PR TITLE
Stop training with custom conditions

### DIFF
--- a/src/trainer.js
+++ b/src/trainer.js
@@ -40,6 +40,13 @@ Trainer.prototype = {
         this.rate = options.rate;
       if (options.cost)
         this.cost = options.cost;
+      if (options.schedule)
+        this.schedule = options.schedule;
+      if (options.customLog){
+        // for back-compat to code that may have use customLog
+        console.log('Deprecated: use schedule instead of customLog')
+        this.schedule = options.customLog;
+      }
     }
 
     currentRate = this.rate;
@@ -71,9 +78,9 @@ Trainer.prototype = {
       error /= set.length;
 
       if (options) {
-        if (options.customLog && options.customLog.every && iterations %
-          options.customLog.every == 0)
-          abort_training = options.customLog.do({
+        if (this.schedule && this.schedule.every && iterations %
+          this.schedule.every == 0)
+          abort_training = this.schedule.do({
             error: error,
             iterations: iterations,
             rate: currentRate
@@ -124,6 +131,12 @@ Trainer.prototype = {
         this.rate = options.rate;
       if (options.cost)
         this.cost = options.cost;
+      if (options.schedule)
+        this.schedule = options.schedule;
+      if (options.customLog)
+        // for back-compat to code that may have use customLog
+        console.log('Deprecated: use schedule instead of customLog')
+        this.schedule = options.customLog;
     }
 
     // dynamic learning rate
@@ -174,8 +187,8 @@ Trainer.prototype = {
 
                 // log
                 if (options) {
-                  if (options.customLog && options.customLog.every && iterations % options.customLog.every == 0)
-                    abort_training = options.customLog.do({
+                  if (this.schedule && this.schedule.every && iterations % this.schedule.every == 0)
+                    abort_training = this.schedule.do({
                       error: error,
                       iterations: iterations
                     });
@@ -261,7 +274,7 @@ Trainer.prototype = {
     var iterations = options.iterations || 100000;
     var rate = options.rate || .1;
     var log = options.log || 0;
-    var customLog = options.customLog || {};
+    var schedule = options.schedule || {};
 
     var trial = correct = i = j = success = 0,
       error = 1,
@@ -359,8 +372,8 @@ Trainer.prototype = {
       if (log && trial % log == 0)
         console.log("iterations:", trial, " success:", success, " correct:",
           correct, " time:", Date.now() - start, " error:", error);
-      if (customLog.do && customLog.every && trial % customLog.every == 0)
-        customLog.do({
+      if (schedule.do && schedule.every && trial % schedule.every == 0)
+        schedule.do({
           iterations: trial,
           success: success,
           error: error,

--- a/src/trainer.js
+++ b/src/trainer.js
@@ -43,7 +43,7 @@ Trainer.prototype = {
       if (options.schedule)
         this.schedule = options.schedule;
       if (options.customLog){
-        // for back-compat to code that may have use customLog
+        // for backward compatibility with code that used customLog
         console.log('Deprecated: use schedule instead of customLog')
         this.schedule = options.customLog;
       }
@@ -134,7 +134,7 @@ Trainer.prototype = {
       if (options.schedule)
         this.schedule = options.schedule;
       if (options.customLog)
-        // for back-compat to code that may have use customLog
+        // for backward compatibility with code that used customLog
         console.log('Deprecated: use schedule instead of customLog')
         this.schedule = options.customLog;
     }

--- a/src/trainer.js
+++ b/src/trainer.js
@@ -175,7 +175,7 @@ Trainer.prototype = {
                 // log
                 if (options) {
                   if (options.customLog && options.customLog.every && iterations % options.customLog.every == 0)
-                    allow_training = allow_training = options.customLog.do({
+                    allow_training = options.customLog.do({
                       error: error,
                       iterations: iterations
                     });

--- a/src/trainer.js
+++ b/src/trainer.js
@@ -18,7 +18,7 @@ Trainer.prototype = {
 
     var error = 1;
     var iterations = bucketSize = 0;
-    var allow_training = true;
+    var abort_training = false;
     var input, output, target, currentRate;
 
     var start = Date.now();
@@ -48,7 +48,7 @@ Trainer.prototype = {
     }
 
 
-    while (allow_training && iterations < this.iterations && error > this.error) {
+    while (!abort_training && iterations < this.iterations && error > this.error) {
       error = 0;
 
       if(bucketSize > 0) {
@@ -73,7 +73,7 @@ Trainer.prototype = {
       if (options) {
         if (options.customLog && options.customLog.every && iterations %
           options.customLog.every == 0)
-          allow_training = options.customLog.do({
+          abort_training = options.customLog.do({
             error: error,
             iterations: iterations,
             rate: currentRate
@@ -175,7 +175,7 @@ Trainer.prototype = {
                 // log
                 if (options) {
                   if (options.customLog && options.customLog.every && iterations % options.customLog.every == 0)
-                    allow_training = options.customLog.do({
+                    abort_training = options.customLog.do({
                       error: error,
                       iterations: iterations
                     });
@@ -186,7 +186,7 @@ Trainer.prototype = {
                     shuffle(set);
                 }
 
-                if (allow_training && iterations < that.iterations && error > that.error)
+                if (!abort_training && iterations < that.iterations && error > that.error)
                 {
                     activateWorker(set[index].input);
                 } else {

--- a/src/trainer.js
+++ b/src/trainer.js
@@ -18,6 +18,7 @@ Trainer.prototype = {
 
     var error = 1;
     var iterations = bucketSize = 0;
+    var allow_training = true;
     var input, output, target, currentRate;
 
     var start = Date.now();
@@ -47,7 +48,7 @@ Trainer.prototype = {
     }
 
 
-    while (iterations < this.iterations && error > this.error) {
+    while (allow_training && iterations < this.iterations && error > this.error) {
       error = 0;
 
       if(bucketSize > 0) {
@@ -72,7 +73,7 @@ Trainer.prototype = {
       if (options) {
         if (options.customLog && options.customLog.every && iterations %
           options.customLog.every == 0)
-          options.customLog.do({
+          allow_training = options.customLog.do({
             error: error,
             iterations: iterations,
             rate: currentRate
@@ -174,7 +175,7 @@ Trainer.prototype = {
                 // log
                 if (options) {
                   if (options.customLog && options.customLog.every && iterations % options.customLog.every == 0)
-                    options.customLog.do({
+                    allow_training = allow_training = options.customLog.do({
                       error: error,
                       iterations: iterations
                     });
@@ -185,7 +186,7 @@ Trainer.prototype = {
                     shuffle(set);
                 }
 
-                if (iterations < that.iterations && error > that.error)
+                if (allow_training && iterations < that.iterations && error > that.error)
                 {
                     activateWorker(set[index].input);
                 } else {

--- a/test/synaptic.js
+++ b/test/synaptic.js
@@ -398,3 +398,27 @@ describe("Cloned Networks Equivalency", function() {
       cloned.propagate(learningRate, target);
   }
 });
+
+describe("Manual Override", function() {
+  var perceptron = new Perceptron(2, 3, 1);
+
+  it('iterations ended at 2000, not full 3000', function(){
+    var final_stats = perceptron.trainer.XOR({
+      iterations: 3000,
+      rate: 0.000001,
+      error: 0.000001,
+      customLog: {
+          every: 1000,
+          do: function(data) {
+            // console.log( data.iterations, 'e', data.error )
+            if( data.iterations == 2000){
+              return false
+            }else{
+              return true
+            }
+          }
+        }
+    });
+    assert.equal( final_stats.iterations, 2000 )
+  });
+});

--- a/test/synaptic.js
+++ b/test/synaptic.js
@@ -410,11 +410,8 @@ describe("Manual Override", function() {
       customLog: {
           every: 1000,
           do: function(data) {
-            // console.log( data.iterations, 'e', data.error )
             if( data.iterations == 2000){
               return false
-            }else{
-              return true
             }
           }
         }

--- a/test/synaptic.js
+++ b/test/synaptic.js
@@ -407,7 +407,7 @@ describe("Manual Override", function() {
       iterations: 3000,
       rate: 0.000001,
       error: 0.000001,
-      customLog: {
+      schedule: {
           every: 1000,
           do: function(data) {
             if( data.iterations == 20000){
@@ -424,7 +424,7 @@ describe("Manual Override", function() {
       iterations: 3000,
       rate: 0.000001,
       error: 0.000001,
-      customLog: {
+      schedule: {
           every: 1000,
           do: function(data) {
             if( data.iterations == 2000){
@@ -436,17 +436,31 @@ describe("Manual Override", function() {
     assert.equal( final_stats.iterations, 2000 )
   });
 
-  it('training works even when customLog() has no return value', function(){
+  it('training works even when schedule() has no return value', function(){
+    var final_stats = perceptron.trainer.XOR({
+      iterations: 3000,
+      rate: 0.000001,
+      error: 0.000001,
+      schedule: {
+          every: 1000,
+          do: function(data) {}
+        }
+    });
+    assert.equal( final_stats.iterations, 3000 )
+  });
+
+  it('using depreciated customLog still works', function(){
+    var counter = 0
     var final_stats = perceptron.trainer.XOR({
       iterations: 3000,
       rate: 0.000001,
       error: 0.000001,
       customLog: {
           every: 1000,
-          do: function(data) {}
+          do: function(data) { counter++ }
         }
     });
-    assert.equal( final_stats.iterations, 3000 )
+    assert.equal( counter, 3 )
   });
 
 });

--- a/test/synaptic.js
+++ b/test/synaptic.js
@@ -402,6 +402,23 @@ describe("Cloned Networks Equivalency", function() {
 describe("Manual Override", function() {
   var perceptron = new Perceptron(2, 3, 1);
 
+  it('iterations ended at full 3000', function(){
+    var final_stats = perceptron.trainer.XOR({
+      iterations: 3000,
+      rate: 0.000001,
+      error: 0.000001,
+      customLog: {
+          every: 1000,
+          do: function(data) {
+            if( data.iterations == 20000){
+              return true
+            }
+          }
+        }
+    });
+    assert.equal( final_stats.iterations, 3000 )
+  });
+
   it('iterations ended at 2000, not full 3000', function(){
     var final_stats = perceptron.trainer.XOR({
       iterations: 3000,
@@ -411,11 +428,25 @@ describe("Manual Override", function() {
           every: 1000,
           do: function(data) {
             if( data.iterations == 2000){
-              return false
+              return true
             }
           }
         }
     });
     assert.equal( final_stats.iterations, 2000 )
   });
+
+  it('training works even when customLog() has no return value', function(){
+    var final_stats = perceptron.trainer.XOR({
+      iterations: 3000,
+      rate: 0.000001,
+      error: 0.000001,
+      customLog: {
+          every: 1000,
+          do: function(data) {}
+        }
+    });
+    assert.equal( final_stats.iterations, 3000 )
+  });
+
 });


### PR DESCRIPTION
[More details here](https://github.com/cazala/synaptic/issues/35):
- If the error increases during training, then I would like to stop training and maybe do something else with this network.

You can put custom logic inside the customLog callback, and return true when you want to stop training.

Returning true stops training, returning false or nothing at all should work as before.

```javascript
customLog: {
  every: 1000,
  do: function(data) {
    // hard stop training when iterations reach 2000
    if( data.iterations == 2000)
      return true
}}
```