### PR TITLE
>=0.10 Node Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "url": "https://github.com/cazala/synaptic/issues"
   },
   "homepage": "http://synaptic.juancazala.com",
-  "engines" : { "node" : "^0.10.0" }
+  "engines" : { "node" : ">=0.10" }
 }


### PR DESCRIPTION
Error by installing on new versions of the Node:

npm WARN engine synaptic@1.0.1: wanted: {"node":"^0.10.0"} (current: {"node":"0.12.7","npm":"2.13.5"})