### PR TITLE
Add missing variable definition in for-loop

### DIFF
--- a/src/architect.js
+++ b/src/architect.js
@@ -28,7 +28,7 @@ var Architect = {
     var previous = input;
 
     // generate hidden layers
-    for (level in layers) {
+    for (var level in layers) {
       var size = layers[level];
       var layer = new Layer(size);
       hidden.push(layer);


### PR DESCRIPTION
Even if missing variable definitions do not break the program, they might do in the future.  E.g. when using strict mode.