### PR TITLE
replaced gulp with mocha in test readme

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
-Test using gulp, from root directory:
+Test using mocha, from root directory:
 
-`gulp test`
+`mocha test`
 
 To test the web version, start a web server at the root dir of this repo, then use your OS browser. 
 


### PR DESCRIPTION
There is no Gulpfile, and I do not see the Gulp module in the devDependencies. Replaced with Mocha as per npm test script. 