### PR TITLE
Train network in a parallel process in Node.js env

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -492,7 +492,11 @@ Network.prototype = {
   },
 
 
-  // Return a HTML5 WebWorker specialized on training the network stored in `memory`.
+  // Train network in a parallel process.
+  // In the web browser environment it returns a HTML5 WebWorker and in Node.js
+  // environment it uses the Child Processes module to return an object with an
+  // WebWorker cloned interface. Both will return a sandboxed script specialized
+  // on training the network stored in `memory`.
   // Train based on the given dataSet and options.
   // The worker returns the updated `memory` when done.
   worker: function(memory, set, options) {
@@ -536,23 +540,37 @@ Network.prototype = {
     if (!this.optimized)
       this.optimize();
 
-    var hardcode = "var inputs = " + this.optimized.data.inputs.length + ";\n";
-    hardcode += "var outputs = " + this.optimized.data.outputs.length + ";\n";
-    hardcode += "var F =  new Float64Array([" + this.optimized.memory.toString() + "]);\n";
-    hardcode += "var activate = " + this.optimized.activate.toString() + ";\n";
-    hardcode += "var propagate = " + this.optimized.propagate.toString() + ";\n";
-    hardcode +=
-        "onmessage = function(e) {\n" +
-          "if (e.data.action == 'startTraining') {\n" +
-            "train(" + JSON.stringify(set) + "," + JSON.stringify(workerOptions) + ");\n" +
-          "}\n" +
-        "}";
+    var hardcode =
+      "var F = new Float64Array([" + this.optimized.memory.join(',') + "]);\n" +
+      "var network = { " + workerFunction + "\n" +
+      "activate: " + this.optimized.activate.toString() + ",\n" +
+      "propagate: " + this.optimized.propagate.toString() + "}\n" +
+      "var onmessage = function(e) {\n" +
+      "  if (e.data.action == 'startTraining') {\n" +
+      "    network.train(" + JSON.stringify(set) + "," + JSON.stringify(workerOptions) + ");\n" +
+      "  }\n" +
+      "}";
 
-    var workerSourceCode = workerFunction + '\n' + hardcode;
-    var blob = new Blob([workerSourceCode]);
-    var blobURL = window.URL.createObjectURL(blob);
+    if (typeof(window)!='undefined' && window.Blob && window.Worker) {
+      var blob = new Blob([hardcode]);
+      var blobURL = window.URL.createObjectURL(blob);
 
-    return new Worker(blobURL);
+      return new Worker(blobURL);
+    }
+    else if (require('child_process')) {
+      // Mimic WebWorker in Node.js environment.
+      var cProcess = require('child_process');
+      var proc = cProcess.fork(__dirname+'/node-worker.js', [hardcode]);
+      proc.postMessage = function(msg){ proc.send(msg) };
+      proc.onmessage = function(){ console.error('must be implemented by the client') };
+      proc.on('message', function(msg){ proc.onmessage({data:msg}) });
+      proc.terminate = function(){ proc.kill('SIGHUP') };
+
+      return proc;
+    }
+    else {
+      throw new Error('This environment has no support for parallel networks.');
+    }
   },
 
   // returns a copy of the network
@@ -578,18 +596,17 @@ Network.getWorkerSharedFunctions = function() {
   //  using the .toString() method
 
   // Load and name the train function
-  var train_f = Trainer.prototype.train.toString();
-  train_f = train_f.replace('function (set', 'function train(set') + '\n';
+  var train_f = 'train: ' + Trainer.prototype.train.toString() + ',\n';
 
   // Load and name the _trainSet function
-  var _trainSet_f = Trainer.prototype._trainSet.toString().replace(/this.network./g, '');
-  _trainSet_f = _trainSet_f.replace('function (set', 'function _trainSet(set') + '\n';
+  var _trainSet_f = Trainer.prototype._trainSet.toString().replace(/this\.network/g, 'this');
+  _trainSet_f = '_trainSet: ' + _trainSet_f + ',\n';
   _trainSet_f = _trainSet_f.replace('this.crossValidate', 'crossValidate');
   _trainSet_f = _trainSet_f.replace('crossValidate = true', 'crossValidate = { }');
 
   // Load and name the test function
-  var test_f = Trainer.prototype.test.toString().replace(/this.network./g, '');
-  test_f = test_f.replace('function (set', 'function test(set') + '\n';
+  var test_f = Trainer.prototype.test.toString().replace(/this\.network/g, 'this');
+  test_f = 'test: ' + test_f + ',\n';
 
   return Network._SHARED_WORKER_FUNCTIONS = train_f + _trainSet_f + test_f;
 };

--- a/src/node-worker.js
+++ b/src/node-worker.js
@@ -1,0 +1,12 @@
+var code = 'process.on("message", function(msg){ onmessage({data:msg}) });\n' +
+           'function postMessage(msg){ process.send(msg) }\n' +
+           process.argv[2];
+
+try {
+  eval(code);
+} catch(err) {
+  process.send({
+    action: 'log',
+    message: 'Synaptic Worker Fail: '+err.message+'\n'+err.stack
+  });
+}

--- a/test/synaptic.js
+++ b/test/synaptic.js
@@ -181,6 +181,44 @@ describe('Basic Neural Network', function () {
     var test1 = Math.round(network.activate([1]));
     assert.equal(test1, 0, "1 did not output 0");
   });
+
+});
+
+describe('Train Async', function () {
+
+  it ('Train XOR', function (done) {
+    var perceptron = new Perceptron(2, 3, 1);
+
+    var trainingSet = [{
+      input: [0, 0],
+      output: [0]
+    }, {
+      input: [0, 1],
+      output: [1]
+    }, {
+      input: [1, 0],
+      output: [1]
+    }, {
+      input: [1, 1],
+      output: [0]
+    }];
+
+    var trainer = new Trainer(perceptron);
+
+    trainer.trainAsync(trainingSet, {
+      iterations: 2000,
+      error: .001
+    }).then(function(){
+      assert.isAtMost( perceptron.activate([0, 0]), .49, "[0,0] did not output 0");
+      assert.isAtLeast(perceptron.activate([0, 1]), .51, "[0,1] did not output 1");
+      assert.isAtLeast(perceptron.activate([1, 0]), .51, "[1,0] did not output 1");
+      assert.isAtMost( perceptron.activate([1, 1]), .49, "[1,1] did not output 0");
+      done();
+    }).catch(function(err){
+      done(err);
+    });
+  });
+
 });
 
 describe("Perceptron - XOR", function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,9 @@ var webpack = require('webpack')
 var license = require('./prebuild.js')
 module.exports = {
   context: __dirname,
+  externals: {
+    child_process: 'null'
+  },
   entry: {
     synaptic: './src/synaptic.js',
     'synaptic.min': './src/synaptic.js'


### PR DESCRIPTION
Mimic WebWorker interface with Child Processes to allow parallel training on Node.js environment, and makes parallel training testable with mocha in a terminal.

To accoumplish this, it makes the method `Network::worker()`and `Network::getWorkerSharedFunctions()` to generate an literal object, to receive stringfyed methods, and giving meaning to `this` keyword.

Also closes #148
