### PR TITLE
Fixed issue in standalone generation ignoring input data

### DIFF
--- a/dist/synaptic.js
+++ b/dist/synaptic.js
@@ -862,7 +862,7 @@ var Network = function () {
       var activation = 'function (input) {\n';
 
       // build inputs
-      for (var i = 0; i < data.inputs; i++) {
+      for (var i = 0; i < data.inputs.length; i++) {
         activation += 'F[' + data.inputs[i] + '] = input[' + i + '];\n';
       } // build network activation
       for (var i = 0; i < data.activate.length; i++) {

--- a/dist/synaptic.min.js
+++ b/dist/synaptic.min.js
@@ -862,7 +862,7 @@ var Network = function () {
       var activation = 'function (input) {\n';
 
       // build inputs
-      for (var i = 0; i < data.inputs; i++) {
+      for (var i = 0; i < data.inputs.length; i++) {
         activation += 'F[' + data.inputs[i] + '] = input[' + i + '];\n';
       } // build network activation
       for (var i = 0; i < data.activate.length; i++) {

--- a/src/Network.js
+++ b/src/Network.js
@@ -427,7 +427,7 @@ export default class Network {
     var activation = 'function (input) {\n';
 
     // build inputs
-    for (var i = 0; i < data.inputs; i++)
+    for (var i = 0; i < data.inputs.length; i++)
       activation += 'F[' + data.inputs[i] + '] = input[' + i + '];\n';
 
     // build network activation


### PR DESCRIPTION
This is a proposed fix to the reported issue #263. It might be better if there was a test, too, and I should look into it, but it least it's starting something moving on this issue.

Put simply, this is needed to make the generated code from `standalone()` refer to the input data correctly. 