### PR TITLE
fix memory leak with Network.fromJSON, remove unused code

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -197,7 +197,7 @@ export default class Layer {
 
 // adds a neuron to the layer
   add(neuron) {
-    this.neurons[neuron.ID] = neuron || new Neuron();
+    neuron = neuron || new Neuron();
     this.list.push(neuron);
     this.size++;
   }


### PR DESCRIPTION
in Layer.js

```this.nerons``` is a function, so ```this.neurons[id] = neuron``` will save neurons to this function's prototype and leak memory

also see discussion https://github.com/cazala/synaptic/issues/164