### PR TITLE
explicitly passing CROSS_ENTROPY to trainer in self-organizing map example

### DIFF
--- a/scripts/controllers/self-organizing-map.js
+++ b/scripts/controllers/self-organizing-map.js
@@ -18,7 +18,7 @@ angular.module('gitHubApp')
 
     var first = true;
     var hopfield = new Architect.Hopfield(80);
-    var trainer = new Trainer(hopfield);
+    var trainer = new Trainer(hopfield, {cost: Trainer.cost.CROSS_ENTROPY});
 
     $scope.valid = function(){
     	var valid = typeof $scope.word == 'string';


### PR DESCRIPTION
In the master branch version of the Hopfield network, the default cost is MSE, but it is CROSS_ENTROPY in the gh-pages branch..  The example cannot work as-is in the master branch version of the library without passing the CROSS_ENTROPY cost function.  I added it to the example to make that more obvious.