### PR TITLE
Added ShuffleInplace implementation to Network's Worker source

### DIFF
--- a/src/Network.js
+++ b/src/Network.js
@@ -516,6 +516,7 @@ export default class Network {
     hardcode += 'var F =  new Float64Array([' + this.optimized.memory.toString() + ']);\n';
     hardcode += 'var activate = ' + this.optimized.activate.toString() + ';\n';
     hardcode += 'var propagate = ' + this.optimized.propagate.toString() + ';\n';
+    hardcode += 'var shuffleInplace = ' + shuffleInplace.toString() + ";\n";
     hardcode +=
       'onmessage = function(e) {\n' +
       'if (e.data.action == \'startTraining\') {\n' +

--- a/src/Network.js
+++ b/src/Network.js
@@ -516,7 +516,7 @@ export default class Network {
     hardcode += 'var F =  new Float64Array([' + this.optimized.memory.toString() + ']);\n';
     hardcode += 'var activate = ' + this.optimized.activate.toString() + ';\n';
     hardcode += 'var propagate = ' + this.optimized.propagate.toString() + ';\n';
-    hardcode += 'var shuffleInplace = ' + shuffleInplace.toString() + ";\n";
+    hardcode += 'function shuffleInplace(o) { for (var j, x, i = o.length; i; j = Math.floor(Math.random() * i), x = o[--i], o[i] = o[j], o[j] = x) {} return o; };\n';
     hardcode +=
       'onmessage = function(e) {\n' +
       'if (e.data.action == \'startTraining\') {\n' +


### PR DESCRIPTION
This PR solves [this issue](https://github.com/cazala/synaptic/issues/238). The problem was that the Worker did not have the shuffleInplace function implemented.

To replicate the error before this commit try to train a network asyncronously with `shuffle: true` in config, like the following:

```
    trainer.trainAsync(trainingSets[channelId], {
        iterations: 2500,
        log: 250,
        rate: 0.01,
        error: 0.01,
        shuffle: true,
        cost: Trainer.cost.CROSS_ENTROPY
    })
```

Both `npm run test` and `npm run build` worked after this alteration locally, but I don't know how to make a failing/suceeding test with this stack, if someone does then feel free to replace this pull request entirely. Tested locally with the built `/dist/synaptic.js` file on a project and validated it fixes the issue too.