### PR TITLE
docs: Fix simple typo, enviroment -> environment

### DIFF
--- a/dist/synaptic.js
+++ b/dist/synaptic.js
@@ -1123,7 +1123,7 @@ var Neuron = function () {
   _createClass(Neuron, [{
     key: 'activate',
     value: function activate(input) {
-      // activation from enviroment (for input neurons)
+      // activation from environment (for input neurons)
       if (typeof input != 'undefined') {
         this.activation = input;
         this.derivative = 0;
@@ -1201,7 +1201,7 @@ var Neuron = function () {
       // whether or not this neuron is in the output layer
       var isOutput = typeof target != 'undefined';
 
-      // output neurons get their error from the enviroment
+      // output neurons get their error from the environment
       if (isOutput) this.error.responsibility = this.error.projected = target - this.activation; // Eq. 10
 
       else // the rest of the neuron compute their error responsibilities by backpropagation

--- a/dist/synaptic.min.js
+++ b/dist/synaptic.min.js
@@ -1123,7 +1123,7 @@ var Neuron = function () {
   _createClass(Neuron, [{
     key: 'activate',
     value: function activate(input) {
-      // activation from enviroment (for input neurons)
+      // activation from environment (for input neurons)
       if (typeof input != 'undefined') {
         this.activation = input;
         this.derivative = 0;
@@ -1201,7 +1201,7 @@ var Neuron = function () {
       // whether or not this neuron is in the output layer
       var isOutput = typeof target != 'undefined';
 
-      // output neurons get their error from the enviroment
+      // output neurons get their error from the environment
       if (isOutput) this.error.responsibility = this.error.projected = target - this.activation; // Eq. 10
 
       else // the rest of the neuron compute their error responsibilities by backpropagation

--- a/src/Neuron.js
+++ b/src/Neuron.js
@@ -62,7 +62,7 @@ export default class Neuron {
 
   // activate the neuron
   activate(input) {
-    // activation from enviroment (for input neurons)
+    // activation from environment (for input neurons)
     if (typeof input != 'undefined') {
       this.activation = input;
       this.derivative = 0;
@@ -142,7 +142,7 @@ export default class Neuron {
     // whether or not this neuron is in the output layer
     var isOutput = typeof target != 'undefined';
 
-    // output neurons get their error from the enviroment
+    // output neurons get their error from the environment
     if (isOutput)
       this.error.responsibility = this.error.projected = target - this.activation; // Eq. 10
 


### PR DESCRIPTION
There is a small typo in dist/synaptic.js, dist/synaptic.min.js, src/Neuron.js.

Should read `environment` rather than `enviroment`.

